### PR TITLE
Call task sheet ResetFill macro after export

### DIFF
--- a/標準モジュール/modIQuavisEntry.txt
+++ b/標準モジュール/modIQuavisEntry.txt
@@ -198,8 +198,18 @@ Public Function ExportTasksToWorksheet(ByVal client As IQuavisClient, _
 
     WriteTasksToWorksheet targetWorksheet, headers, flatRows
 
+    Call ResetWorksheetFillIfAvailable(targetWorksheet)
+
     ExportTasksToWorksheet = flatRows.count
 End Function
+
+Private Sub ResetWorksheetFillIfAvailable(ByVal ws As Worksheet)
+    If ws Is Nothing Then Exit Sub
+
+    On Error Resume Next
+    CallByName ws, "ResetFill_ThisSheet", VbMethod, False
+    On Error GoTo 0
+End Sub
 
 Public Function ApplyTaskUpdates(ByVal client As IQuavisClient, _
                                  ByVal wsTasks As Worksheet, _


### PR DESCRIPTION
## Summary
- invoke the worksheet's `ResetFill_ThisSheet` macro after writing exported tasks so template fill colors are cleared

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de17f0dd648329b323de0d44f51a68