### PR TITLE
Fix RemoveIllegalCharacters for Unicode exports

### DIFF
--- a/標準モジュール/modExcelExport.txt
+++ b/標準モジュール/modExcelExport.txt
@@ -82,10 +82,13 @@ End Function
 
 Private Function RemoveIllegalCharacters(ByVal text As String) As String
     Dim i As Long
-    Dim code As Integer
+    Dim code As Long
     Dim builder As String
     For i = 1 To Len(text)
-        code = Asc(Mid$(text, i, 1))
+        code = AscW(Mid$(text, i, 1))
+        If code < 0 Then
+            code = code + 65536
+        End If
         If code = 9 Or code = 10 Or code = 13 Or code >= 32 Then
             builder = builder & Mid$(text, i, 1)
         End If


### PR DESCRIPTION
## Summary
- allow RemoveIllegalCharacters to handle full Unicode code points by storing character codes as Long
- switch to AscW and normalize negative return values so multi-byte characters are preserved

## Testing
- not run (Excel-dependent scenario not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de20f53dfc83298be3427cff7fa652