### PR TITLE
Fix sheet existence check without raising error

### DIFF
--- a/標準モジュール/modProjectActions.txt
+++ b/標準モジュール/modProjectActions.txt
@@ -898,9 +898,15 @@ End Function
 
 Private Function SheetExists(ByVal wb As Workbook, ByVal sheetName As String) As Boolean
     Dim wsCandidate As Worksheet
-    On Error Resume Next
-    Set wsCandidate = wb.Worksheets(sheetName)
-    SheetExists = Not wsCandidate Is Nothing
+
+    SheetExists = False
+
+    For Each wsCandidate In wb.Worksheets
+        If StrComp(wsCandidate.Name, sheetName, vbBinaryCompare) = 0 Then
+            SheetExists = True
+            Exit For
+        End If
+    Next wsCandidate
+
     Set wsCandidate = Nothing
-    On Error GoTo 0
 End Function


### PR DESCRIPTION
## Summary
- replace the worksheet lookup that relied on runtime error handling with an explicit iteration that compares sheet names to avoid out-of-range errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de47c869e083298cfb57601ac0c0c3